### PR TITLE
feat: add default permissions configuration to settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -7,5 +7,8 @@
   },
   "includeCoAuthoredBy": false,
   "model": "opus",
-  "theme": "dark"
+  "theme": "dark",
+  "permissions": {
+    "defaultMode": "acceptEdits"
+  }
 }


### PR DESCRIPTION
## Summary
- Add permissions configuration to settings.json
- Set defaultMode to 'acceptEdits' as the default permission handling

## Changes Made
- Added `permissions` object with `defaultMode` property to settings.json
- This standardizes permission handling across the application

## Test plan
- [ ] Verify settings.json is valid JSON
- [ ] Confirm permissions object is properly structured
- [ ] Test that the application reads the new permission settings correctly